### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete string escaping or encoding

### DIFF
--- a/frontend/scripts/translation-service.cjs
+++ b/frontend/scripts/translation-service.cjs
@@ -254,7 +254,7 @@ Output the translated JSON:`;
     // Fix nested quotes issues
     fixed = fixed.replace(/"([^"]*)"(\s*:\s*)"([^"]*)"/g, (match, key, colon, value) => {
       // Escape any quotes within the value
-      const escapedValue = value.replace(/"/g, '\\"');
+      const escapedValue = value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
       return `"${key}"${colon}"${escapedValue}"`;
     });
 


### PR DESCRIPTION
Potential fix for [https://github.com/aws-samples/sample-group-chat-ai/security/code-scanning/2](https://github.com/aws-samples/sample-group-chat-ai/security/code-scanning/2)

**General fix:**  
To correctly escape strings for JSON, we must escape backslashes (`\`) before escaping quotes (`"`), to avoid double-escaping or missed escapes. The best way is to replace all backslashes with double backslashes, and then escape quotes by replacing all `"` with `\"`. This ensures that any existing backslashes are not mistakenly treated as escape characters. Alternatively, one could use `JSON.stringify`, but since this is happening in a custom handler inside a regex callback, a manual escaping sequence is appropriate and less invasive.

**Specific fix:**  
Edit line 257 inside the callback on lines 255-259. Change the line:

```js
const escapedValue = value.replace(/"/g, '\\"');
```
to

```js
const escapedValue = value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
```

This change is local to the function containing line 257 in `frontend/scripts/translation-service.cjs` and does not require other imports or method changes.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
