### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete string escaping or encoding

### DIFF
--- a/frontend/scripts/translation-service.cjs
+++ b/frontend/scripts/translation-service.cjs
@@ -234,8 +234,8 @@ Output the translated JSON:`;
 
     // Ensure proper string quoting
     cleaned = cleaned.replace(/:\s*'([^']*)'/g, (match, p1) => {
-      // Replace single quotes with double quotes, escaping internal quotes
-      return ': "' + p1.replace(/"/g, '\\"').replace(/\n/g, ' ') + '"';
+      // Replace single quotes with double quotes, escaping backslashes and internal quotes
+      return ': "' + p1.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, ' ') + '"';
     });
 
     return cleaned;


### PR DESCRIPTION
Potential fix for [https://github.com/aws-samples/sample-group-chat-ai/security/code-scanning/1](https://github.com/aws-samples/sample-group-chat-ai/security/code-scanning/1)

The best and most robust fix is to ensure that any backslash characters in `p1` are escaped (`\\`) when constructing new string literals. This should be done **before** escaping double quotes, to prevent doubly escaping previously inserted escapes. The change will be within the existing replacer function at line 236–239.

- Update the `p1.replace()` chain to first escape backslashes (`\\` → `\\\\`), then double quotes (`"` → `\"`), then newlines (`\n` → `' '`).
- Only the code within the replacer/arrow function at lines 236–239 needs to be changed.
- No additional libraries or imports are strictly needed for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
